### PR TITLE
Add (limited) support for pipes (`|`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "nash"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "dirs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nash"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Closes #2 

This is version `1.0.0` of `NaSH`, which adds limited support for handling pipes. Note that #6 is not fixed by this PR